### PR TITLE
Fix for 0.18.1

### DIFF
--- a/src/untar.nim
+++ b/src/untar.nim
@@ -77,7 +77,11 @@ iterator walk*(tar: TarFile): tuple[info: FileInfo, contents: string] =
 
     # Gather info about the file/dir.
     let filename = header[0 .. 100]
-    let fileSize = parseOctInt(header[124 .. 134])
+    var fileSize = 0
+    try:
+      fileSize = parseOctInt(header[124 .. 134])
+    except ValueError:
+      discard
     let typeFlag = header[156]
 
     # U-Star


### PR DESCRIPTION
Using #head, needed this change along with minor changes to readStr() and peekStr() to work around ""[0] issue.

Tested with 0.18.0 as well as #head.