### PR TITLE
make `ZlibError` inherit from IOError

### DIFF
--- a/src/untar/gzip.nim
+++ b/src/untar/gzip.nim
@@ -37,7 +37,7 @@ type
     pos: int
     isAtEnd: bool
 
-  ZlibError* = object of Exception
+  ZlibError* = object of IOError
 
 proc checkZlibError(ret: cint, handle: GzFilePtr) =
   if ret == Z_ERRNO:


### PR DESCRIPTION
Changes `ZlibError` to inherit from `IOError` instead of `Exception`. Otherwise assigning `gzClose` to `Socket.closeImpl` isn't possible, due to the changes done in https://github.com/nim-lang/Nim/pull/10453.

However, I'm not sure if it should be `OSError` instead.